### PR TITLE
refactor: 장바구니 링크 수정 및 찜 목록 개발(#38)

### DIFF
--- a/css/like_menu.css
+++ b/css/like_menu.css
@@ -174,16 +174,13 @@ a {
 /* 리스트 */
 .menu_list {
   text-decoration: none; /* 밑줄 제거 */
-
   margin-right: 25px;
   margin-left: 25px;
-
   display: flex;
   flex-direction: column;
   gap: 16px;
   list-style: none;
 }
-
 /* 카드 베이스 */
 .menu_card {
   position: relative;
@@ -191,7 +188,7 @@ a {
   border-radius: 16px;
   overflow: hidden;
   box-shadow: 0 6px 18px rgba(0, 0, 0, 0.12);
-  padding: 16px;
+  padding: 15px;
 }
 
 /* 상단 레이아웃 */
@@ -292,3 +289,16 @@ a {
   color: #8b8b8b;
   font-size: 14px;
 }
+/* 공통 빈 상태 스타일: 가게/메뉴 동일 적용 */
+.menu_empty_card {
+  background: #fff;
+  border-radius: 16px;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.12);
+  padding: 25px 20px;
+  text-align: center;
+}
+
+.menu_empty_msg {
+font-size: 16px; /* 원하는 크기 */
+  font-weight: 600;
+  color: #666;

--- a/css/like_store.css
+++ b/css/like_store.css
@@ -185,6 +185,25 @@ a {
   overflow: hidden;
   box-shadow: 0 6px 18px rgba(0, 0, 0, 0.12);
 }
+.store_card .like_btn {
+  position: absolute;
+  right: 15px; /* 오른쪽 여백 */
+  bottom: 8px; /* 아래 여백 */
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+}
+
+.store_card .like_btn img {
+  width: 22px;
+  height: 20px;
+}
+.store_card.empty_card .empty_msg {
+  font-size: 16px; /* 원하는 크기 */
+  font-weight: 600;
+  color: #666;
+}
 
 .badge {
   position: absolute;
@@ -206,7 +225,7 @@ a {
 }
 
 .meta {
-  padding: 14px 18px;
+  padding: 10px 18px;
   display: flex;
 }
 
@@ -225,19 +244,4 @@ a {
   font-size: 15px;
   color: #2b7de9;
   text-decoration: none;
-}
-
-/* 하트 버튼 – 꽉찬/라인 두 상태 */
-.like_btn {
-  border: none;
-  background: transparent;
-  padding: 0;
-  width: 22px;
-  height: 20px;
-  margin-left: 135px;
-}
-.like_btn img {
-  width: 100%;
-  height: 100%;
-  object-fit: contain;
 }

--- a/css/purchase_log.css
+++ b/css/purchase_log.css
@@ -148,8 +148,9 @@ a {
   background: #f1f1f1;
   color: #111;
   border-radius: 0 0 22px 22px;
-  height: auto;
+  padding: 12px 16px; /* CTA와 균형 */
 }
+
 .my_review_title {
   font-weight: 700;
   margin-bottom: 6px;

--- a/js/home_menu.js
+++ b/js/home_menu.js
@@ -22,9 +22,18 @@ document.addEventListener("DOMContentLoaded", () => {
     searchActive: false,
   };
 
+  /* ===== 찜(메뉴) 엔드포인트 ===== */
+  // POST   /api/v1/menus/{menuId}/favorite     -> 추가
+  // DELETE /api/v1/favorites/menus/{menuId}    -> 삭제
+  const like_api = {
+    like: (id) => `${API_BASE}/api/v1/menus/${id}/favorite`,
+    unlike: (id) => `${API_BASE}/api/v1/favorites/menus/${id}`,
+  };
+  const like_inflight = new Set(); // 클릭 연타 방지
+
   /* ===== 초기화 ===== */
   const hadAlias = applySelectedLocationAlias(); // 세션/캐시 우선 반영
-  if (!hadAlias && $addr) $addr.textContent = "주소 설정"; // "홍제동" 가리기
+  if (!hadAlias && $addr) $addr.textContent = "주소 설정";
   fetchActiveAndApply(); // 서버 활성 위치로 최종 덮어쓰기
   if ($sortBtn) $sortBtn.textContent = sortLabel(state.sortType);
   fetchAndRender();
@@ -56,6 +65,41 @@ document.addEventListener("DOMContentLoaded", () => {
   });
 
   /* ===== 유틸 ===== */
+  // 메뉴ID -> 스토어ID 캐시
+  const menuToStoreCache = new Map();
+
+  async function fetchStoreIdByMenu(menuId) {
+    try {
+      const res = await fetch(`${API_BASE}/api/v1/menus/${menuId}`, {
+        method: "GET",
+        credentials: "include",
+      });
+      if (!res.ok) throw new Error(`menu detail ${res.status}`);
+      const data = await res.json().catch(() => null);
+      const m = data?.result ?? data;
+      // 네가 이미 가진 getStoreId(m) 재사용 + 후보 키 보강
+      const cand = [
+        getStoreId(m),
+        m?.storeId,
+        m?.store_id,
+        m?.store?.id,
+        m?.store?.storeId,
+        m?.store?.store_id,
+      ];
+      for (const v of cand) if (v !== undefined && v !== null) return v;
+    } catch (e) {
+      console.warn("storeId resolve failed for menu:", menuId, e);
+    }
+    return null;
+  }
+
+  async function resolveStoreId(menuId) {
+    if (menuToStoreCache.has(menuId)) return menuToStoreCache.get(menuId);
+    const sid = await fetchStoreIdByMenu(menuId);
+    if (sid) menuToStoreCache.set(menuId, sid);
+    return sid;
+  }
+
   const PLACEHOLDER_IMG = "../images/store_placeholder.png"; // 프로젝트에 준비 권장
 
   // 백엔드 필드명 호환: menuImage | imageUrl | storeImageUrl | store.imageUrl
@@ -69,7 +113,20 @@ document.addEventListener("DOMContentLoaded", () => {
     );
   }
 
-  /* ===== 함수들 ===== */
+  // 링크에 넣을 storeId 추출 (응답 편차 흡수)
+  function getStoreId(m) {
+    const cand = [
+      m?.storeId,
+      m?.store_id,
+      m?.store?.id,
+      m?.store?.storeId,
+      m?.store?.store_id,
+      m?.store?.store?.id,
+    ];
+    for (const v of cand) if (v !== undefined && v !== null) return v;
+    return null;
+  }
+
   function sortLabel(t) {
     return t === "DISCOUNT"
       ? "할인순"
@@ -107,6 +164,7 @@ document.addEventListener("DOMContentLoaded", () => {
     return `${API_BASE}/api/v1/menus?${q.toString()}`;
   }
 
+  /* ===== 데이터 ===== */
   async function fetchAndRender() {
     if (state.loading || !state.hasMore) return;
     state.loading = true;
@@ -143,7 +201,7 @@ document.addEventListener("DOMContentLoaded", () => {
   function getLastMenuId(list) {
     if (!list?.length) return state.cursor ?? null;
     const last = list[list.length - 1];
-    return last?.menuId ?? state.cursor ?? null;
+    return last?.menuId ?? last?.id ?? state.cursor ?? null;
   }
 
   function resetAndReload() {
@@ -158,87 +216,95 @@ document.addEventListener("DOMContentLoaded", () => {
     const kw = (keyword || "").trim().toLowerCase();
     if (!kw) return state.menus;
     return state.menus.filter((m) =>
-      String(m.name || "")
+      String(m.name || m.menuName || "")
         .toLowerCase()
         .includes(kw)
     );
   }
 
+  /* ===== 렌더 ===== */
   function renderList(menus) {
     if (!$list) return;
 
     if (!menus?.length) {
       $list.innerHTML = `
-    <li class="menu_card empty_card" aria-live="polite">
-      <div class="menu_link" style="display:flex;justify-content:center;padding:10px 0">
-        <strong class="name empty_msg">표시할 메뉴가 없습니다</strong>
-      </div>
-    </li>`;
+      <li class="menu_empty_card" aria-live="polite">
+        <p class="menu_empty_msg">표시할 메뉴가 없습니다</p>
+      </li>`;
       return;
     }
 
     const frag = document.createDocumentFragment();
+
     menus.forEach((m) => {
       const li = document.createElement("li");
       li.className = "menu_card";
 
-      const liked = state.likes.has(m.menuId);
+      const menuId = m.menuId ?? m.id;
+      const menuName = m.name ?? m.menuName ?? "메뉴";
+      const liked = state.likes.has(menuId);
 
-      // 가격/할인 계산
-      const price = Number(m.price) || 0;
-      const discount = Number(m.discountPercent) || 0;
+      const price = Number(m.price ?? m.originalPrice) || 0;
+      const discount = Number(m.discountPercent ?? m.discount_rate) || 0;
       const hasDiscount = discount > 0;
-      const salePrice = hasDiscount
-        ? Math.round(price * (1 - discount / 100))
-        : price;
+      const salePrice =
+        "discountPrice" in m
+          ? Number(m.discountPrice) || Math.round(price * (1 - discount / 100))
+          : hasDiscount
+          ? Math.round(price * (1 - discount / 100))
+          : price;
+
+      const storeIdFromList = getStoreId(m);
+
+      // ⚠️ 상세 조회 없이 바로 이동: storeId 없으면 menuId만 전달
+      const href = storeIdFromList
+        ? `order.html?storeId=${encodeURIComponent(
+            storeIdFromList
+          )}&menuId=${encodeURIComponent(menuId)}`
+        : `order.html?menuId=${encodeURIComponent(menuId)}`;
 
       li.innerHTML = `
-        <button class="like_btn" aria-label="찜" data-menu-id="${m.menuId}">
-          <img src="${
-            liked ? "../images/like_red.svg" : "../images/like.svg"
-          }" alt="찜" />
-        </button>
-        <a href="order.html?menuId=${encodeURIComponent(
-          m.menuId
-        )}" class="menu_link">
-          <div class="menu_top">
-            <div class="menu_left">
-              <p class="menu_name">${escapeHtml(m.name || "메뉴")}</p>
-
-              <div class="price_block">
-                ${
-                  hasDiscount
-                    ? `<span class="old_price">${formatWon(price)} 원</span>
-                       <div class="now_row">
-                         <span class="sale_pct">${Math.round(discount)}%</span>
-                         <span class="now_price">${formatWon(
-                           salePrice
-                         )} 원</span>
-                       </div>`
-                    : `<div class="now_row">
-                         <span class="now_price">${formatWon(price)} 원</span>
-                       </div>`
-                }
-              </div>
-            </div>
-
-            <div class="menu_right">
-              <img class="menu_thumb"
-                   src="${getImageUrl(m)}"
-                   alt="${escapeHtml(m.name || "메뉴")}">
+      <button class="like_btn" aria-label="찜" data-menu-id="${menuId}">
+        <img src="${
+          liked ? "../images/like_red.svg" : "../images/like.svg"
+        }" alt="찜" />
+      </button>
+      <a href="${href}" class="menu_link" data-store-id="${
+        storeIdFromList ?? ""
+      }">
+        <div class="menu_top">
+          <div class="menu_left">
+            <p class="menu_name">${escapeHtml(menuName)}</p>
+            <div class="price_block">
+              ${
+                hasDiscount
+                  ? `<span class="old_price">${formatWon(price)} 원</span>
+                     <div class="now_row">
+                       <span class="sale_pct">${Math.round(discount)}%</span>
+                       <span class="now_price">${formatWon(salePrice)} 원</span>
+                     </div>`
+                  : `<div class="now_row">
+                       <span class="now_price">${formatWon(price)} 원</span>
+                     </div>`
+              }
             </div>
           </div>
-
-          <!-- 스펙상 storeName/distance 없음 → 하단 라인은 숨김 -->
-        </a>
-      `;
+          <div class="menu_right">
+            <img class="menu_thumb"
+                 src="${getImageUrl(m)}"
+                 alt="${escapeHtml(menuName)}"
+                 onerror="this.onerror=null;this.src='${PLACEHOLDER_IMG}'">
+          </div>
+        </div>
+      </a>
+    `;
 
       frag.appendChild(li);
     });
 
     $list.replaceChildren(frag);
 
-    // 찜 토글
+    // 찜 토글 바인딩
     $list.querySelectorAll(".like_btn").forEach((btn) => {
       btn.addEventListener("click", (e) => {
         e.preventDefault();
@@ -249,19 +315,71 @@ document.addEventListener("DOMContentLoaded", () => {
     });
   }
 
-  function toggleLike(menuId, btnEl) {
-    if (state.likes.has(menuId)) state.likes.delete(menuId);
-    else state.likes.add(menuId);
+  /* ===== 찜 토글(서버 동기화 + 낙관적 UI) ===== */
+  async function toggleLike(menuId, btnEl) {
+    if (like_inflight.has(menuId)) return; // 연타 방지
+    like_inflight.add(menuId);
+
+    const wasLiked = state.likes.has(menuId);
+    const nowLiked = !wasLiked;
+
+    // 1) 낙관적 업데이트 (UI + 메모리 + 로컬)
+    applyLikeUI(btnEl, nowLiked);
+    if (nowLiked) state.likes.add(menuId);
+    else state.likes.delete(menuId);
+    persistLikes();
+
+    try {
+      const url = nowLiked ? like_api.like(menuId) : like_api.unlike(menuId);
+      const method = nowLiked ? "POST" : "DELETE";
+
+      const res = await fetch(url, { method, credentials: "include" });
+      if (res.status === 401) {
+        rollback();
+        alert("로그인이 필요합니다. 다시 로그인해주세요.");
+        window.location.href = "../pages/login.html";
+        return;
+      }
+      if (!res.ok)
+        throw new Error(`menu like api ${method} failed: ${res.status}`);
+
+      // (선택) 응답 favoritedStatus 동기화
+      const data = await res.json().catch(() => null);
+      const status =
+        data?.result?.favoritedStatus ?? data?.favoritedStatus ?? nowLiked;
+
+      if (status !== nowLiked) {
+        applyLikeUI(btnEl, status);
+        if (status) state.likes.add(menuId);
+        else state.likes.delete(menuId);
+        persistLikes();
+      }
+    } catch (e) {
+      console.error(e);
+      rollback();
+      alert("찜 처리에 실패했어요. 잠시 후 다시 시도해주세요.");
+    } finally {
+      like_inflight.delete(menuId);
+    }
+
+    function rollback() {
+      applyLikeUI(btnEl, wasLiked);
+      if (wasLiked) state.likes.add(menuId);
+      else state.likes.delete(menuId);
+      persistLikes();
+    }
+  }
+
+  function applyLikeUI(btnEl, liked) {
+    const img = btnEl?.querySelector("img");
+    if (img) img.src = liked ? "../images/like_red.svg" : "../images/like.svg";
+  }
+
+  function persistLikes() {
     localStorage.setItem(
       "likes_menu",
       JSON.stringify(Array.from(state.likes.values()))
     );
-    const img = btnEl.querySelector("img");
-    if (img) {
-      img.src = state.likes.has(menuId)
-        ? "../images/like_red.svg"
-        : "../images/like.svg";
-    }
   }
 
   function formatWon(n) {
@@ -298,7 +416,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
       const road = loc?.roadAddressName || null;
 
-      // ✅ 별칭 우선 표시 (별칭 없을 때만 road, 그것도 없으면 기존 locationName)
+      // ✅ 별칭 우선 표시
       const label = alias || road || loc?.locationName || null;
 
       if (label && $addr) {
@@ -310,7 +428,7 @@ document.addEventListener("DOMContentLoaded", () => {
             "selected_location",
             JSON.stringify({
               id: loc.locationId,
-              name: label, // 상단 표시와 동일하게 별칭 저장
+              name: label,
               lat: Number(loc.latitude),
               lng: Number(loc.longitude),
             })

--- a/js/like_menu.js
+++ b/js/like_menu.js
@@ -1,0 +1,276 @@
+// ../js/like_menu.js
+// 규칙: 모든 요청은 credentials:'include' (JWT 쿠키)
+
+document.addEventListener("DOMContentLoaded", () => {
+  /* ===== 설정 ===== */
+  const API_BASE = "https://api-whynotbuy.store";
+  const PAGE_SIZE = 10;
+  const PLACEHOLDER_IMG = "../images/store_placeholder.png";
+
+  /* ===== 엘리먼트 ===== */
+  const $list = document.querySelector(".menu_list");
+  const $search = document.querySelector(".search_bar input");
+  const $sortBtn = document.querySelector(".near_btn"); // 최신순 고정 → 비활성
+
+  /* ===== 상태 ===== */
+  const state = {
+    cursor: null, // 마지막으로 본 favoriteId
+    hasMore: true,
+    loading: false,
+    raw: [], // 서버 원본(최신순)
+    view: [], // 검색 적용 뷰
+    likes: new Set(JSON.parse(localStorage.getItem("likes_menu") || "[]")), // menuId 캐시
+    inflight: new Set(), // 삭제 연타 방지(menuId)
+  };
+
+  // 버튼 비활성(최신순 고정)
+  if ($sortBtn) {
+    $sortBtn.textContent = "최신순";
+    $sortBtn.style.opacity = "0.5";
+    $sortBtn.style.pointerEvents = "none";
+    $sortBtn.title = "최신순 고정 정렬";
+  }
+
+  /* ===== 초기 로드 ===== */
+  fetchAndAppend();
+
+  /* ===== 이벤트 ===== */
+  let timer;
+  $search?.addEventListener("input", () => {
+    clearTimeout(timer);
+    timer = setTimeout(() => applyFilter(($search.value || "").trim()), 120);
+  });
+
+  window.addEventListener("scroll", () => {
+    if (state.loading || !state.hasMore) return;
+    const nearBottom =
+      window.innerHeight + window.scrollY >= document.body.offsetHeight - 200;
+    if (nearBottom) fetchAndAppend();
+  });
+
+  /* ===== API ===== */
+  function buildListUrl() {
+    const q = new URLSearchParams();
+    if (state.cursor != null) q.set("cursor", String(state.cursor));
+    q.set("size", String(PAGE_SIZE));
+    return `${API_BASE}/api/v1/favorites/menus?${q.toString()}`;
+  }
+
+  async function fetchAndAppend() {
+    if (state.loading || !state.hasMore) return;
+    state.loading = true;
+
+    try {
+      const res = await fetch(buildListUrl(), {
+        method: "GET",
+        credentials: "include",
+      });
+      if (res.status === 401) {
+        alert("로그인이 필요합니다. 다시 로그인해주세요.");
+        window.location.href = "../pages/login.html";
+        return;
+      }
+
+      const data = await res.json();
+      // Swagger: result.FavoriteMenus / favoriteMenus
+      const result = data?.result ?? data;
+      const list = result?.favoriteMenus ?? result?.FavoriteMenus ?? [];
+
+      const batch = Array.isArray(list) ? list : [];
+      state.raw = state.raw.concat(batch);
+
+      // cursor / hasData 키 호환
+      state.cursor =
+        result?.nextCursor !== undefined
+          ? result.nextCursor
+          : getLastFavId(batch);
+      state.hasMore =
+        typeof result?.hasData === "boolean"
+          ? result.hasData
+          : batch.length === PAGE_SIZE;
+
+      // 캐시 동기화(이 페이지는 '내가 찜한 메뉴'라 캐시에 추가)
+      for (const it of batch) {
+        if (it?.menuId != null) state.likes.add(it.menuId);
+      }
+      persistLikes();
+
+      applyFilter($search?.value || "");
+    } catch (e) {
+      console.error("내 찜 메뉴 목록 조회 실패:", e);
+    } finally {
+      state.loading = false;
+    }
+  }
+
+  function getLastFavId(list) {
+    if (!list?.length) return state.cursor ?? null;
+    return list[list.length - 1]?.favoriteId ?? state.cursor ?? null;
+  }
+
+  async function deleteFavorite(menuId) {
+    if (state.inflight.has(menuId)) return;
+    state.inflight.add(menuId);
+
+    // 낙관적 제거
+    const beforeRaw = state.raw.slice();
+    const beforeLikes = new Set(state.likes);
+    removeFromState(menuId);
+    render(state.view);
+
+    try {
+      const url = `${API_BASE}/api/v1/favorites/menus/${menuId}`;
+      const res = await fetch(url, {
+        method: "DELETE",
+        credentials: "include",
+      });
+      if (!res.ok) throw new Error(`unfavorite menu failed: ${res.status}`);
+
+      // (선택) 응답에 favoritedStatus 있으면 검증 가능
+      // const data = await res.json().catch(() => null);
+    } catch (e) {
+      console.error(e);
+      // 롤백
+      state.raw = beforeRaw;
+      state.likes = beforeLikes;
+      persistLikes();
+      applyFilter($search?.value || "");
+      alert("찜 해제에 실패했어요. 잠시 후 다시 시도해주세요.");
+    } finally {
+      state.inflight.delete(menuId);
+    }
+  }
+
+  /* ===== 렌더/필터 ===== */
+  function applyFilter(keyword) {
+    const kw = (keyword || "").toLowerCase();
+    state.view = !kw
+      ? state.raw.slice()
+      : state.raw.filter((m) =>
+          [String(m.menuName || ""), String(m.storeName || "")]
+            .join(" ")
+            .toLowerCase()
+            .includes(kw)
+        );
+    render(state.view);
+  }
+
+  function render(items) {
+    if (!$list) return;
+
+    if (!items?.length) {
+      $list.innerHTML = `
+    <li class="menu_empty_card" aria-live="polite">
+      <p class="menu_empty_msg">찜한 메뉴가 없습니다</p>
+    </li>`;
+      return;
+    }
+
+    const frag = document.createDocumentFragment();
+
+    items.forEach((m) => {
+      const li = document.createElement("li");
+      li.className = "menu_card";
+
+      const menuId = m.menuId;
+      const storeId = m.storeId;
+      const menuName = m.menuName || "메뉴";
+      const storeName = m.storeName || "";
+      const price = Number(m.price) || 0;
+      const discount = Number(m.discountPercent) || 0;
+      const hasDiscount = discount > 0;
+      const salePrice =
+        "discountPrice" in m
+          ? Number(m.discountPrice) || Math.round(price * (1 - discount / 100))
+          : Math.round(price * (1 - discount / 100));
+      const img = m.menuImage || PLACEHOLDER_IMG;
+      const liked = state.likes.has(menuId);
+
+      li.innerHTML = `
+        <button class="like_btn" aria-label="찜 해제" data-menu-id="${menuId}">
+          <img src="${
+            liked ? "../images/like_red.svg" : "../images/like.svg"
+          }" alt="찜" />
+        </button>
+        <a href="order.html?storeId=${encodeURIComponent(
+          storeId
+        )}&menuId=${encodeURIComponent(menuId)}" class="menu_link">
+          <div class="menu_top">
+            <div class="menu_left">
+              <p class="menu_name">${escapeHtml(menuName)}</p>
+              <div class="price_block">
+                ${
+                  hasDiscount
+                    ? `
+                      <span class="old_price">${fmt(price)} 원</span>
+                      <div class="now_row">
+                        <span class="sale_pct">${Math.round(discount)}%</span>
+                        <span class="now_price">${fmt(salePrice)} 원</span>
+                      </div>
+                    `
+                    : `
+                      <div class="now_row">
+                        <span class="now_price">${fmt(price)} 원</span>
+                      </div>
+                    `
+                }
+              </div>
+            </div>
+            <div class="menu_right">
+              <img class="menu_thumb"
+                   src="${img}"
+                   alt="${escapeHtml(menuName)}"
+                   onerror="this.onerror=null;this.src='${PLACEHOLDER_IMG}'">
+            </div>
+          </div>
+          <div class="menu_bottom">
+            <div class="store_line">
+              <span class="store_name">${escapeHtml(storeName)}</span>
+            </div>
+          </div>
+        </a>
+      `;
+
+      frag.appendChild(li);
+    });
+
+    $list.replaceChildren(frag);
+
+    // 하트 클릭 → 찜 해제(DELETE) + 카드 제거
+    $list.querySelectorAll(".like_btn").forEach((btn) => {
+      btn.addEventListener("click", (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        const id = Number(btn.dataset.menuId);
+        deleteFavorite(id);
+      });
+    });
+  }
+
+  /* ===== 상태 유틸 ===== */
+  function removeFromState(menuId) {
+    state.raw = state.raw.filter((x) => x.menuId !== menuId);
+    state.view = state.view.filter((x) => x.menuId !== menuId);
+    if (state.likes.has(menuId)) {
+      state.likes.delete(menuId);
+      persistLikes();
+    }
+  }
+
+  function persistLikes() {
+    localStorage.setItem("likes_menu", JSON.stringify([...state.likes]));
+  }
+
+  /* ===== 포맷/공통 ===== */
+  function fmt(n) {
+    return Number(n).toLocaleString("ko-KR");
+  }
+  function escapeHtml(str) {
+    return String(str)
+      .replaceAll("&", "&amp;")
+      .replaceAll("<", "&lt;")
+      .replaceAll(">", "&gt;")
+      .replaceAll('"', "&quot;")
+      .replaceAll("'", "&#039;");
+  }
+});

--- a/js/like_store.js
+++ b/js/like_store.js
@@ -1,0 +1,251 @@
+// ../js/like_store.js
+// 규칙: JWT는 쿠키에 저장되어 있고, 모든 요청은 credentials: 'include'
+
+document.addEventListener("DOMContentLoaded", () => {
+  /* ===== 설정 ===== */
+  const API_BASE = "https://api-whynotbuy.store";
+  const PAGE_SIZE = 10;
+  const PLACEHOLDER_IMG = "../images/store_placeholder.png";
+
+  /* ===== 엘리먼트 ===== */
+  const $list = document.querySelector(".store_list");
+  const $search = document.querySelector(".search_bar input");
+  const $sortBtn = document.querySelector(".near_btn"); // 즐겨찾기 API는 최신순 고정이므로 비활성화 표시만
+
+  /* ===== 상태 ===== */
+  const state = {
+    cursor: null, // 마지막으로 본 favoriteId
+    hasMore: true, // 다음 페이지 여부
+    loading: false,
+    raw: [], // 서버에서 받은 원본(최신순)
+    view: [], // 검색 필터 적용된 뷰
+    likes: new Set(JSON.parse(localStorage.getItem("likes_store") || "[]")), // storeId 캐시
+    inflight: new Set(), // 삭제 연타 방지 (storeId)
+  };
+
+  // 버튼 라벨/상태(즐겨찾기 목록은 서버가 최신순으로 내려줌)
+  if ($sortBtn) {
+    $sortBtn.textContent = "최신순";
+    $sortBtn.style.opacity = "0.5";
+    $sortBtn.style.pointerEvents = "none";
+    $sortBtn.title = "최신순 고정 정렬";
+  }
+
+  /* ===== 초기 로드 ===== */
+  fetchAndAppend();
+
+  /* ===== 이벤트 ===== */
+  // 검색 (클라이언트 필터)
+  let timer;
+  $search?.addEventListener("input", () => {
+    clearTimeout(timer);
+    timer = setTimeout(() => {
+      applyFilter(($search.value || "").trim());
+    }, 120);
+  });
+
+  // 무한 스크롤
+  window.addEventListener("scroll", () => {
+    if (state.loading || !state.hasMore) return;
+    const nearBottom =
+      window.innerHeight + window.scrollY >= document.body.offsetHeight - 200;
+    if (nearBottom) fetchAndAppend();
+  });
+
+  /* ===== API ===== */
+
+  function buildListUrl() {
+    const q = new URLSearchParams();
+    if (state.cursor != null) q.set("cursor", String(state.cursor));
+    q.set("size", String(PAGE_SIZE));
+    return `${API_BASE}/api/v1/favorites/stores?${q.toString()}`;
+  }
+
+  async function fetchAndAppend() {
+    if (state.loading || !state.hasMore) return;
+    state.loading = true;
+
+    try {
+      const res = await fetch(buildListUrl(), {
+        method: "GET",
+        credentials: "include",
+      });
+
+      if (res.status === 401) {
+        alert("로그인이 필요합니다. 다시 로그인해주세요.");
+        window.location.href = "../pages/login.html";
+        return;
+      }
+
+      const data = await res.json();
+
+      // 스웨거 예시: { isSuccess, result:{ favoriteStores:[], nextCursor, hasData } }
+      const payload = data?.result ?? data;
+      const batch = Array.isArray(
+        payload?.favoriteStores || payload?.FavoriteStores
+      )
+        ? payload.favoriteStores || payload.FavoriteStores
+        : [];
+
+      state.raw = state.raw.concat(batch);
+      state.cursor =
+        payload?.nextCursor !== undefined
+          ? payload.nextCursor
+          : getLastFavId(batch);
+      state.hasMore =
+        typeof payload?.hasData === "boolean"
+          ? payload.hasData
+          : batch.length === PAGE_SIZE;
+
+      // 첫 로드 시 캐시 동기화(없던 storeId면 추가)
+      // 이 페이지는 "내가 찜한 것"만 보이므로, 캐시에 없으면 추가해 둔다.
+      for (const it of batch) {
+        if (it?.storeId != null) state.likes.add(it.storeId);
+      }
+      persistLikes();
+
+      applyFilter($search?.value || "");
+    } catch (e) {
+      console.error("내 찜 가게 목록 조회 실패:", e);
+    } finally {
+      state.loading = false;
+    }
+  }
+
+  function getLastFavId(list) {
+    if (!list?.length) return state.cursor ?? null;
+    const last = list[list.length - 1];
+    return last?.favoriteId ?? state.cursor ?? null;
+  }
+
+  async function deleteFavorite(storeId, btnEl) {
+    if (state.inflight.has(storeId)) return;
+    state.inflight.add(storeId);
+
+    // 낙관적 제거: UI/상태에서 먼저 빼기
+    const beforeRaw = state.raw.slice();
+    const beforeLikes = new Set(state.likes);
+    removeFromState(storeId);
+    render(state.view);
+
+    try {
+      const url = `${API_BASE}/api/v1/favorites/stores/${storeId}`;
+      const res = await fetch(url, {
+        method: "DELETE",
+        credentials: "include",
+      });
+
+      if (!res.ok) throw new Error(`unfavorite failed: ${res.status}`);
+
+      // (선택) 서버 응답에 favoritedStatus가 오면 불일치 시 되돌릴 수 있음
+      // const data = await res.json().catch(() => null);
+    } catch (e) {
+      console.error(e);
+      // 롤백
+      state.raw = beforeRaw;
+      state.likes = beforeLikes;
+      persistLikes();
+      applyFilter($search?.value || "");
+      alert("찜 해제에 실패했어요. 잠시 후 다시 시도해주세요.");
+    } finally {
+      state.inflight.delete(storeId);
+    }
+  }
+
+  /* ===== 렌더/필터 ===== */
+
+  function applyFilter(keyword) {
+    const kw = (keyword || "").toLowerCase();
+    if (!kw) {
+      state.view = state.raw.slice();
+    } else {
+      state.view = state.raw.filter((s) =>
+        String(s.storeName || "")
+          .toLowerCase()
+          .includes(kw)
+      );
+    }
+    render(state.view);
+  }
+
+  function render(items) {
+    if (!$list) return;
+
+    if (!items?.length) {
+      $list.innerHTML = `
+        <li class="store_card empty_card" aria-live="polite">
+          <div class="meta" style="justify-content:center; padding:25px 0">
+            <strong class="name empty_msg">찜한 가게가 없습니다</strong>
+          </div>
+        </li>`;
+      return;
+    }
+
+    const frag = document.createDocumentFragment();
+
+    items.forEach((s) => {
+      const li = document.createElement("li");
+      li.className = "store_card";
+
+      const storeId = s.storeId;
+      const name = s.storeName || "가게";
+      const img = s.storeImage || PLACEHOLDER_IMG;
+
+      li.innerHTML = `
+        <a href="store_home.html?storeId=${encodeURIComponent(storeId)}">
+          <img class="thumb" src="${img}" alt="${escapeHtml(name)}" />
+          <div class="meta">
+            <div class="title_row">
+              <strong class="name">${escapeHtml(name)}</strong>
+              <a class="distance"></a>
+            </div>
+            <button class="like_btn" type="button" aria-label="찜 해제" data-store-id="${storeId}">
+              <img src="../images/like_red.svg" alt="찜 해제" />
+            </button>
+          </div>
+        </a>
+      `;
+
+      frag.appendChild(li);
+    });
+
+    $list.replaceChildren(frag);
+
+    // 하트(빨강) 클릭 → 찜 삭제
+    $list.querySelectorAll(".like_btn").forEach((btn) => {
+      btn.addEventListener("click", (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        const id = Number(btn.dataset.storeId);
+        deleteFavorite(id, btn);
+      });
+    });
+  }
+
+  /* ===== 상태 업데이트 유틸 ===== */
+
+  function removeFromState(storeId) {
+    // raw에서 제거
+    state.raw = state.raw.filter((x) => x.storeId !== storeId);
+    // view도 제거
+    state.view = state.view.filter((x) => x.storeId !== storeId);
+    // 캐시에서도 제거
+    if (state.likes.has(storeId)) {
+      state.likes.delete(storeId);
+      persistLikes();
+    }
+  }
+
+  function persistLikes() {
+    localStorage.setItem("likes_store", JSON.stringify([...state.likes]));
+  }
+
+  function escapeHtml(str) {
+    return String(str)
+      .replaceAll("&", "&amp;")
+      .replaceAll("<", "&lt;")
+      .replaceAll(">", "&gt;")
+      .replaceAll('"', "&quot;")
+      .replaceAll("'", "&#039;");
+  }
+});

--- a/js/order.js
+++ b/js/order.js
@@ -1,290 +1,299 @@
 // 메뉴 주문 페이지 JavaScript - 완전히 새로운 코드
 document.addEventListener("DOMContentLoaded", () => {
-  
-    // 기본 설정
-    const API_BASE = "https://api-whynotbuy.store";
-    
-    // DOM 요소들
-    const $topTitle = document.querySelector(".top_title");
-    const $menuTitle = document.querySelector(".menu_title");
-    const $priceStrike = document.querySelector(".price_strike");
-    const $saleRate = document.querySelector(".sale_rate");
-    const $salePrice = document.querySelector(".sale_price");
-    const $menuImg = document.querySelector(".menu_img img");
-    const $menuDesc = document.querySelector(".menu_desc");
-    const $quantityValue = document.querySelector(".quantity_value");
-    const $minusBtn = document.querySelector(".quantity_button1");
-    const $plusBtn = document.querySelector(".quantity_button2");
-    const $cartButton = document.querySelector(".cart_button");
-    const $cartButtonPrice = document.querySelector(".cart_button_price");
-    const $backArrow = document.querySelector("#back_arrow");
-  
-    // 상태 관리
-    const appState = {
-      storeId: null,
-      menuId: null,
-      storeInfo: null,
-      menuInfo: null,
-      quantity: 1
-    };
-  
-    // 앱 시작
-    init();
-  
-    async function init() {
-      console.log("=== ORDER.JS 초기화 시작 ===");
-      
-      // URL 파라미터 추출
-      extractParams();
-      
-      if (!appState.storeId || !appState.menuId) {
-        alert("메뉴 정보를 찾을 수 없습니다.");
-        window.history.back();
-        return;
-      }
-      
-      // 이벤트 리스너 등록
-      setupEvents();
-      
-      // 데이터 로드
-      await loadStoreData();
-      await loadMenuData();
-      
-      console.log("=== ORDER.JS 초기화 완료 ===");
+  // 기본 설정
+  const API_BASE = "https://api-whynotbuy.store";
+
+  // DOM 요소들
+  const $topTitle = document.querySelector(".top_title");
+  const $menuTitle = document.querySelector(".menu_title");
+  const $priceStrike = document.querySelector(".price_strike");
+  const $saleRate = document.querySelector(".sale_rate");
+  const $salePrice = document.querySelector(".sale_price");
+  const $menuImg = document.querySelector(".menu_img img");
+  const $menuDesc = document.querySelector(".menu_desc");
+  const $quantityValue = document.querySelector(".quantity_value");
+  const $minusBtn = document.querySelector(".quantity_button1");
+  const $plusBtn = document.querySelector(".quantity_button2");
+  const $cartButton = document.querySelector(".cart_button");
+  const $cartButtonPrice = document.querySelector(".cart_button_price");
+  const $backArrow = document.querySelector("#back_arrow");
+
+  // 상태 관리
+  const appState = {
+    storeId: null,
+    menuId: null,
+    storeInfo: null,
+    menuInfo: null,
+    quantity: 1,
+  };
+
+  // 앱 시작
+  init();
+
+  async function init() {
+    console.log("=== ORDER.JS 초기화 시작 ===");
+
+    // URL 파라미터 추출
+    extractParams();
+
+    if (!appState.storeId || !appState.menuId) {
+      alert("메뉴 정보를 찾을 수 없습니다.");
+      window.history.back();
+      return;
     }
-  
-    function extractParams() {
-      const params = new URLSearchParams(window.location.search);
-      appState.storeId = parseInt(params.get('storeId'));
-      appState.menuId = parseInt(params.get('menuId'));
-      
-      console.log("URL 파라미터:", {
-        storeId: appState.storeId,
-        menuId: appState.menuId
+
+    // 이벤트 리스너 등록
+    setupEvents();
+
+    // 데이터 로드
+    await loadStoreData();
+    await loadMenuData();
+
+    console.log("=== ORDER.JS 초기화 완료 ===");
+  }
+
+  function extractParams() {
+    const params = new URLSearchParams(window.location.search);
+    appState.storeId = parseInt(params.get("storeId"));
+    appState.menuId = parseInt(params.get("menuId"));
+
+    console.log("URL 파라미터:", {
+      storeId: appState.storeId,
+      menuId: appState.menuId,
+    });
+  }
+
+  function setupEvents() {
+    // 수량 버튼 스타일 및 이벤트
+    if ($minusBtn) {
+      $minusBtn.style.cursor = "pointer";
+      $minusBtn.addEventListener("click", () => changeQuantity(-1));
+    }
+
+    if ($plusBtn) {
+      $plusBtn.style.cursor = "pointer";
+      $plusBtn.addEventListener("click", () => changeQuantity(1));
+    }
+
+    // 뒤로가기 버튼
+    if ($backArrow) {
+      $backArrow.addEventListener("click", (e) => {
+        e.preventDefault();
+        window.location.href = `store_home.html?storeId=${appState.storeId}`;
       });
     }
-  
-    function setupEvents() {
-      // 수량 버튼 스타일 및 이벤트
-      if ($minusBtn) {
-        $minusBtn.style.cursor = 'pointer';
-        $minusBtn.addEventListener('click', () => changeQuantity(-1));
-      }
-      
-      if ($plusBtn) {
-        $plusBtn.style.cursor = 'pointer';
-        $plusBtn.addEventListener('click', () => changeQuantity(1));
-      }
-      
-      // 뒤로가기 버튼
-      if ($backArrow) {
-        $backArrow.addEventListener('click', (e) => {
-          e.preventDefault();
-          window.location.href = `store_home.html?storeId=${appState.storeId}`;
-        });
-      }
-      
-      // 장바구니 담기 버튼
-      if ($cartButton) {
-        $cartButton.addEventListener('click', addToServerCart);
-      }
-      
-      console.log("이벤트 리스너 등록 완료");
+
+    // 장바구니 담기 버튼
+    if ($cartButton) {
+      $cartButton.addEventListener("click", addToServerCart);
     }
-  
-    async function loadStoreData() {
-      try {
-        console.log("가게 정보 로딩 시작...");
-        
-        const response = await fetch(`${API_BASE}/api/v1/store/${appState.storeId}`, {
-          method: 'GET',
-          credentials: 'include'
-        });
-        
-        if (!response.ok) {
-          throw new Error(`가게 정보 로드 실패: ${response.status}`);
+
+    console.log("이벤트 리스너 등록 완료");
+  }
+
+  async function loadStoreData() {
+    try {
+      console.log("가게 정보 로딩 시작...");
+
+      const response = await fetch(
+        `${API_BASE}/api/v1/store/${appState.storeId}`,
+        {
+          method: "GET",
+          credentials: "include",
         }
-        
-        const data = await response.json();
-        appState.storeInfo = data.result || data;
-        
-        // 가게명 표시
-        if ($topTitle && appState.storeInfo.name) {
-          $topTitle.textContent = appState.storeInfo.name;
+      );
+
+      if (!response.ok) {
+        throw new Error(`가게 정보 로드 실패: ${response.status}`);
+      }
+
+      const data = await response.json();
+      appState.storeInfo = data.result || data;
+
+      // 가게명 표시
+      if ($topTitle && appState.storeInfo.name) {
+        $topTitle.textContent = appState.storeInfo.name;
+      }
+
+      console.log("가게 정보 로딩 완료:", appState.storeInfo.name);
+    } catch (error) {
+      console.error("가게 정보 로딩 실패:", error);
+    }
+  }
+
+  async function loadMenuData() {
+    try {
+      console.log("메뉴 정보 로딩 시작...");
+
+      const response = await fetch(
+        `${API_BASE}/api/v1/store/${appState.storeId}/menus/${appState.menuId}`,
+        {
+          method: "GET",
+          credentials: "include",
         }
-        
-        console.log("가게 정보 로딩 완료:", appState.storeInfo.name);
-        
-      } catch (error) {
-        console.error("가게 정보 로딩 실패:", error);
+      );
+
+      if (!response.ok) {
+        throw new Error(`메뉴 정보 로드 실패: ${response.status}`);
+      }
+
+      const data = await response.json();
+      appState.menuInfo = data.result || data;
+
+      // 메뉴 정보 화면에 표시
+      displayMenuInfo();
+
+      console.log("메뉴 정보 로딩 완료:", appState.menuInfo.name);
+    } catch (error) {
+      console.error("메뉴 정보 로딩 실패:", error);
+      alert("메뉴 정보를 불러오는데 실패했습니다.");
+    }
+  }
+
+  function displayMenuInfo() {
+    const menu = appState.menuInfo;
+
+    // 메뉴명
+    if ($menuTitle) {
+      $menuTitle.textContent = menu.name || "메뉴명 없음";
+    }
+
+    // 가격 정보
+    const originalPrice = menu.price || 0;
+    const discountPercent = menu.discountPercent || 0;
+    const discountedPrice = Math.round(
+      originalPrice * (1 - discountPercent / 100)
+    );
+
+    // 정가 (할인이 있을 때만)
+    if ($priceStrike) {
+      if (discountPercent > 0) {
+        $priceStrike.textContent = `${originalPrice.toLocaleString()} 원`;
+        $priceStrike.style.display = "block";
+      } else {
+        $priceStrike.style.display = "none";
       }
     }
-  
-    async function loadMenuData() {
-      try {
-        console.log("메뉴 정보 로딩 시작...");
-        
-        const response = await fetch(`${API_BASE}/api/v1/store/${appState.storeId}/menus/${appState.menuId}`, {
-          method: 'GET',
-          credentials: 'include'
-        });
-        
-        if (!response.ok) {
-          throw new Error(`메뉴 정보 로드 실패: ${response.status}`);
-        }
-        
-        const data = await response.json();
-        appState.menuInfo = data.result || data;
-        
-        // 메뉴 정보 화면에 표시
-        displayMenuInfo();
-        
-        console.log("메뉴 정보 로딩 완료:", appState.menuInfo.name);
-        
-      } catch (error) {
-        console.error("메뉴 정보 로딩 실패:", error);
-        alert('메뉴 정보를 불러오는데 실패했습니다.');
+
+    // 할인율 (할인이 있을 때만)
+    if ($saleRate) {
+      if (discountPercent > 0) {
+        $saleRate.textContent = `${discountPercent}%`;
+        $saleRate.style.display = "inline";
+      } else {
+        $saleRate.style.display = "none";
       }
     }
-  
-    function displayMenuInfo() {
-      const menu = appState.menuInfo;
-      
-      // 메뉴명
-      if ($menuTitle) {
-        $menuTitle.textContent = menu.name || '메뉴명 없음';
+
+    // 판매가
+    if ($salePrice) {
+      const finalPrice = discountPercent > 0 ? discountedPrice : originalPrice;
+      $salePrice.textContent = `${finalPrice.toLocaleString()} 원`;
+    }
+
+    // 메뉴 이미지
+    if ($menuImg) {
+      $menuImg.src = menu.menuImage || "../images/sample_pizza.jpg";
+      $menuImg.alt = menu.name || "메뉴 이미지";
+    }
+
+    // 메뉴 설명
+    if ($menuDesc) {
+      $menuDesc.textContent = menu.description || "메뉴 설명이 없습니다.";
+    }
+
+    // 장바구니 버튼 가격 업데이트
+    updateCartButtonPrice();
+  }
+
+  function changeQuantity(delta) {
+    const newQuantity = appState.quantity + delta;
+
+    if (newQuantity >= 1 && newQuantity <= 99) {
+      appState.quantity = newQuantity;
+
+      // 수량 표시 업데이트
+      if ($quantityValue) {
+        $quantityValue.textContent = `${appState.quantity} 개`;
       }
-      
-      // 가격 정보
-      const originalPrice = menu.price || 0;
-      const discountPercent = menu.discountPercent || 0;
-      const discountedPrice = Math.round(originalPrice * (1 - discountPercent / 100));
-      
-      // 정가 (할인이 있을 때만)
-      if ($priceStrike) {
-        if (discountPercent > 0) {
-          $priceStrike.textContent = `${originalPrice.toLocaleString()} 원`;
-          $priceStrike.style.display = 'block';
-        } else {
-          $priceStrike.style.display = 'none';
-        }
-      }
-      
-      // 할인율 (할인이 있을 때만)
-      if ($saleRate) {
-        if (discountPercent > 0) {
-          $saleRate.textContent = `${discountPercent}%`;
-          $saleRate.style.display = 'inline';
-        } else {
-          $saleRate.style.display = 'none';
-        }
-      }
-      
-      // 판매가
-      if ($salePrice) {
-        const finalPrice = discountPercent > 0 ? discountedPrice : originalPrice;
-        $salePrice.textContent = `${finalPrice.toLocaleString()} 원`;
-      }
-      
-      // 메뉴 이미지
-      if ($menuImg) {
-        $menuImg.src = menu.menuImage || '../images/sample_pizza.jpg';
-        $menuImg.alt = menu.name || '메뉴 이미지';
-      }
-      
-      // 메뉴 설명
-      if ($menuDesc) {
-        $menuDesc.textContent = menu.description || '메뉴 설명이 없습니다.';
-      }
-      
+
       // 장바구니 버튼 가격 업데이트
       updateCartButtonPrice();
+
+      console.log("수량 변경:", appState.quantity);
     }
-  
-    function changeQuantity(delta) {
-      const newQuantity = appState.quantity + delta;
-      
-      if (newQuantity >= 1 && newQuantity <= 99) {
-        appState.quantity = newQuantity;
-        
-        // 수량 표시 업데이트
-        if ($quantityValue) {
-          $quantityValue.textContent = `${appState.quantity} 개`;
-        }
-        
-        // 장바구니 버튼 가격 업데이트
-        updateCartButtonPrice();
-        
-        console.log("수량 변경:", appState.quantity);
-      }
+  }
+
+  function updateCartButtonPrice() {
+    if (!$cartButtonPrice || !appState.menuInfo) return;
+
+    const originalPrice = appState.menuInfo.price || 0;
+    const discountPercent = appState.menuInfo.discountPercent || 0;
+    const discountedPrice = Math.round(
+      originalPrice * (1 - discountPercent / 100)
+    );
+    const finalPrice = discountPercent > 0 ? discountedPrice : originalPrice;
+    const totalPrice = finalPrice * appState.quantity;
+
+    $cartButtonPrice.textContent = `${totalPrice.toLocaleString()}원`;
+  }
+
+  async function addToServerCart() {
+    if (!appState.menuInfo) {
+      alert("메뉴 정보가 없습니다.");
+      return;
     }
-  
-    function updateCartButtonPrice() {
-      if (!$cartButtonPrice || !appState.menuInfo) return;
-      
-      const originalPrice = appState.menuInfo.price || 0;
-      const discountPercent = appState.menuInfo.discountPercent || 0;
-      const discountedPrice = Math.round(originalPrice * (1 - discountPercent / 100));
-      const finalPrice = discountPercent > 0 ? discountedPrice : originalPrice;
-      const totalPrice = finalPrice * appState.quantity;
-      
-      $cartButtonPrice.textContent = `${totalPrice.toLocaleString()}원`;
-    }
-  
-    async function addToServerCart() {
-      if (!appState.menuInfo) {
-        alert('메뉴 정보가 없습니다.');
-        return;
-      }
-      
-      try {
-        console.log("=== 서버 장바구니 추가 시작 ===");
-        console.log("요청 데이터:", {
+
+    try {
+      console.log("=== 서버 장바구니 추가 시작 ===");
+      console.log("요청 데이터:", {
+        menuId: appState.menuId,
+        quantity: appState.quantity,
+      });
+
+      const response = await fetch(`${API_BASE}/api/v1/carts`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        credentials: "include",
+        body: JSON.stringify({
           menuId: appState.menuId,
-          quantity: appState.quantity
-        });
-        
-        const response = await fetch(`${API_BASE}/api/v1/carts`, {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json'
-          },
-          credentials: 'include',
-          body: JSON.stringify({
-            menuId: appState.menuId,
-            quantity: appState.quantity
-          })
-        });
-        
-        console.log("응답 상태 코드:", response.status);
-        
-        if (!response.ok) {
-          throw new Error(`장바구니 추가 실패: ${response.status} ${response.statusText}`);
-        }
-        
-        const responseData = await response.json();
-        console.log("서버 응답 데이터:", responseData);
-        
-        
-        // 응답 데이터를 URL 파라미터로 전달하여 store_home으로 이동
-        const cartDataString = encodeURIComponent(JSON.stringify(responseData.result));
-        const targetUrl = `store_home.html?storeId=${appState.storeId}&cartData=${cartDataString}`;
-        
-        console.log("이동할 URL:", targetUrl);
-        console.log("=== 서버 장바구니 추가 완료 ===");
-        
-        window.location.href = targetUrl;
-        
-      } catch (error) {
-        console.error("장바구니 추가 에러:", error);
-        
-        if (error.message.includes('401')) {
-          alert('로그인이 필요합니다.');
-        } else if (error.message.includes('404')) {
-          alert('메뉴를 찾을 수 없습니다.');
-        } else {
-          alert('장바구니에 추가하는데 실패했습니다. 다시 시도해주세요.');
-        }
+          quantity: appState.quantity,
+        }),
+      });
+
+      console.log("응답 상태 코드:", response.status);
+
+      if (!response.ok) {
+        throw new Error(
+          `장바구니 추가 실패: ${response.status} ${response.statusText}`
+        );
+      }
+
+      const responseData = await response.json();
+      console.log("서버 응답 데이터:", responseData);
+
+      // 응답 데이터를 URL 파라미터로 전달하여 store_home으로 이동
+      const cartDataString = encodeURIComponent(
+        JSON.stringify(responseData.result)
+      );
+      const targetUrl = `store_home.html?storeId=${appState.storeId}&cartData=${cartDataString}`;
+
+      console.log("이동할 URL:", targetUrl);
+      console.log("=== 서버 장바구니 추가 완료 ===");
+
+      window.location.href = targetUrl;
+    } catch (error) {
+      console.error("장바구니 추가 에러:", error);
+
+      if (error.message.includes("401")) {
+        alert("로그인이 필요합니다.");
+      } else if (error.message.includes("404")) {
+        alert("메뉴를 찾을 수 없습니다.");
+      } else {
+        alert("장바구니에 추가하는데 실패했습니다. 다시 시도해주세요.");
       }
     }
-  });
+  }
+});

--- a/js/write_review.js
+++ b/js/write_review.js
@@ -23,7 +23,7 @@ document.addEventListener("DOMContentLoaded", () => {
     return;
   }
   const target = JSON.parse(targetRaw);
-  // target: { order_id, store_name, items:[{name,qty}], old_price, sale_pct, now_price, order_date_label, order_code }
+  // target: { order_id, store_name, items:[{name,qty}] | ["문자열"], old_price, sale_pct, now_price, order_date_label, order_code }
 
   // ===== UI 채우기
   $orderDate.textContent = target.order_date_label || "";
@@ -33,7 +33,6 @@ document.addEventListener("DOMContentLoaded", () => {
   $orderCode.href = "#";
   $storeName.textContent = target.store_name || "";
 
-  // 아이템 리스트
   // 아이템 리스트 (문자열/객체 모두 대응)
   $orderItems.innerHTML = "";
   (target.items || []).forEach((it) => {
@@ -88,8 +87,6 @@ document.addEventListener("DOMContentLoaded", () => {
         }),
       });
 
-      const data = await res.json().catch(() => ({}));
-
       if (!res.ok) {
         // 401 등 인증 실패 시 로그인으로
         if (res.status === 401 || res.status === 403) {
@@ -101,11 +98,25 @@ document.addEventListener("DOMContentLoaded", () => {
       }
 
       if (data?.isSuccess) {
+        // 🔴 방금 리뷰 쓴 주문ID를 기록 → 구매내역에서 곧바로 '내 리뷰'로 보이도록 (낙관적 표시)
+        const reviewedIds = new Set(
+          JSON.parse(sessionStorage.getItem("reviewed_order_ids") || "[]").map(
+            String
+          )
+        );
+        reviewedIds.add(String(target.order_id));
+        sessionStorage.setItem(
+          "reviewed_order_ids",
+          JSON.stringify([...reviewedIds])
+        );
+
         alert("리뷰가 등록되었습니다.");
-        // 사용한 세션 데이터 정리
+
+        // 🔴 사용한 세션 데이터 정리
         sessionStorage.removeItem("review_target");
-        // 구매내역으로 복귀
-        window.location.href = "../pages/purchase_log.html";
+
+        // 🔴 구매내역으로 복귀 (BFCache 이슈 방지 위해 replace + updated=1 쿼리)
+        window.location.replace("../pages/purchase_log.html?updated=1");
       } else {
         throw new Error(data?.message || "리뷰 등록에 실패했습니다.");
       }

--- a/pages/home_menu.html
+++ b/pages/home_menu.html
@@ -30,7 +30,7 @@
           </div>
 
           <div class="cart_btn">
-            <a href="purchase_log.html">
+            <a href="cart.html">
               <img src="../images/cart.svg" alt="장바구니" />
             </a>
           </div>

--- a/pages/home_store.html
+++ b/pages/home_store.html
@@ -30,7 +30,7 @@
           </div>
 
           <div class="cart_btn">
-            <a href="purchase_log.html">
+            <a href="cart.html">
               <img src="../images/cart.svg" alt="장바구니" />
             </a>
           </div>

--- a/pages/like_menu.html
+++ b/pages/like_menu.html
@@ -28,7 +28,7 @@
           </div>
 
           <div class="cart_btn">
-            <a href="purchase_log.html">
+            <a href="cart.html">
               <img src="../images/cart.svg" alt="장바구니" />
             </a>
           </div>
@@ -230,6 +230,6 @@
       </div>
     </div>
 
-    <!-- <script src="../js/like_menu.js"></script> -->
+    <script src="../js/like_menu.js"></script>
   </body>
 </html>

--- a/pages/like_store.html
+++ b/pages/like_store.html
@@ -28,7 +28,7 @@
           </div>
 
           <div class="cart_btn">
-            <a href="purchase_log.html">
+            <a href="cart.html">
               <img src="../images/cart.svg" alt="장바구니" />
             </a>
           </div>
@@ -54,71 +54,7 @@
 
       <div class="content">
         <ul class="store_list">
-          <!-- 카드 1 -->
-          <!-- 예시 카드 -->
-          <li class="store_card">
-            <a href="store_home.html">
-              <span class="badge">최대 10% 할인중</span>
-              <img
-                class="thumb"
-                src="../images/sample_bingsu_1.jpg"
-                alt="삼형제 빙수"
-              />
-              <div class="meta">
-                <div class="title_row">
-                  <strong class="name">삼형제 빙수</strong>
-                  <a class="distance">500m</a>
-                </div>
-                <button class="like_btn">
-                  <img src="../images/like_red.svg" alt="찜" />
-                </button>
-              </div>
-            </a>
-          </li>
-
-          <!-- 카드 2 -->
-          <!-- 예시 카드 -->
-          <li class="store_card">
-            <a href="store_home.html">
-              <span class="badge">최대 10% 할인중</span>
-              <img
-                class="thumb"
-                src="../images/sample_bingsu_1.jpg"
-                alt="삼형제 빙수"
-              />
-              <div class="meta">
-                <div class="title_row">
-                  <strong class="name">삼형제 빙수</strong>
-                  <a class="distance">500m</a>
-                </div>
-                <button class="like_btn">
-                  <img src="../images/like_red.svg" alt="찜" />
-                </button>
-              </div>
-            </a>
-          </li>
-
-          <!-- 카드 2 -->
-          <!-- 예시 카드 -->
-          <li class="store_card">
-            <a href="store_home.html">
-              <span class="badge">최대 10% 할인중</span>
-              <img
-                class="thumb"
-                src="../images/sample_bingsu_1.jpg"
-                alt="삼형제 빙수"
-              />
-              <div class="meta">
-                <div class="title_row">
-                  <strong class="name">삼형제 빙수</strong>
-                  <a class="distance">500m</a>
-                </div>
-                <button class="like_btn">
-                  <img src="../images/like_red.svg" alt="찜" />
-                </button>
-              </div>
-            </a>
-          </li>
+         
         </ul>
       </div>
 
@@ -147,6 +83,6 @@
       </div>
     </div>
 
-    <!-- <script src="../js/like_store.js"></script> -->
+    <script src="../js/like_store.js"></script>
   </body>
 </html>


### PR DESCRIPTION
# ☝️Issue Number

Close #38 

##  📌 개요

- 장바구니 링크 수정 및 찜 목록 개발

## 🔁 변경 사항
장바구니 링크 잘못 돼있던 것 수정
찜목록 가게별, 메뉴별 개발완료

## 📸 스크린샷
<img width="602" height="1297" alt="like_store" src="https://github.com/user-attachments/assets/613faaee-8120-495b-87a5-2e29c3df00d9" />
<img width="783" height="1287" alt="like_menu" src="https://github.com/user-attachments/assets/c30331fa-7f48-44db-8036-a2c84dcb0c7b" />

## 👀 기타 더 이야기해볼 점
-리뷰올리기 검토필요(사용자가 쓴 리뷰를 모아놓는 백엔드 확인 필요, 프론트에서 해야할지 백엔드인지 서치 필요)
-home_menu에서 특정 메뉴를 클릭했을 때 order로 연결이 안됨 like_menu에서 특정 메뉴를 클릭했을 떄는 order로 연결이 됨
( "메뉴 목록 조회 API" 에 가게 정보가 담겨있는지 확인 필요 / 현우님과 해결 완료)
